### PR TITLE
Disposed animation controller

### DIFF
--- a/lib/draggable_widget.dart
+++ b/lib/draggable_widget.dart
@@ -194,6 +194,12 @@ class _DraggableWidgetState extends State<DraggableWidget>
     });
     super.initState();
   }
+  
+  @override
+  void dispose() {
+    animationController.dispose();
+    super.dispose();
+  }
 
   @override
   void didUpdateWidget(DraggableWidget oldWidget) {


### PR DESCRIPTION
Tickers used by AnimationControllers should be disposed by calling dispose() on the AnimationController itself. Otherwise, the ticker will leak.